### PR TITLE
fix(auth): sign session cookie store with sessionSecret, not clientId

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -162,7 +162,7 @@ app
     if (settings.network.trustProxy) {
       server.enable('trust proxy');
     }
-    server.use(cookieParser(settings.clientId));
+    server.use(cookieParser(settings.sessionSecret));
     server.use(express.json());
     server.use(express.urlencoded({ extended: true }));
     server.use((req, _res, next) => {


### PR DESCRIPTION
Targets the OIDC login PR in seerr-team/seerr#2715, where this branch is the head.

## Problem

`cookie-parser` is initialized with `settings.clientId` (the Plex client UUID), but `express-session` signs `connect.sid` with `settings.sessionSecret`. The two secrets differ, so cookie-parser's signature check on `connect.sid` fails. When that happens, cookie-parser moves the entry out of `req.cookies` and into `req.signedCookies` with value `false`. The OpenAPI request validator then checks:

```js
if (!req.cookies[scheme.name] && !req.signedCookies?.[scheme.name]) {
    throw Error(\`cookie '\${scheme.name}' required\`);
}
```

Both checks pass (undefined / false are falsy), so every authenticated request 401s with ` + "`cookie 'connect.sid' required`" + ` even though the browser is sending the cookie correctly.

The breakage was introduced in a272ef6c (\"fix: use signed session cookie to persist state & code_verifier, clear after login\") when ` + "`cookieParser()`" + ` was changed to ` + "`cookieParser(settings.clientId)`" + `. Picking ` + "`clientId`" + ` looks like a slip; the natural pairing is the secret express-session is already using.

## Fix

Use ` + "`settings.sessionSecret`" + ` so cookie-parser and express-session share the same secret. The OIDC ` + "`oidc-code-verifier`" + ` and ` + "`oidc-state`" + ` cookies are stored via ` + "`res.cookie(..., { signed: true })`" + ` and read back through ` + "`req.signedCookies[KEY]`" + ` in the callback, which also continues to work since they go through cookie-parser's same secret on the way in and out.

## Repro

1. Run ` + "`seerr/seerr:preview-new-oidc`" + ` behind a reverse proxy with HTTPS and ` + "`network.trustProxy: true`" + `.
2. Configure an OIDC provider, set ` + "`main.oidcLogin: true`" + ` and ` + "`main.mediaServerLogin: false`" + `.
3. Click the OIDC button, sign in at the IdP.
4. Browser bounces back to ` + "`/login?code=...&state=...`" + `, ` + "`POST /api/v1/auth/oidc/callback/:slug`" + ` returns 204 (session row is written to the store, ` + "`Set-Cookie: connect.sid=...`" + ` is on the response, browser stores it).
5. Frontend follows up with ` + "`GET /api/v1/auth/me`" + `, sends the ` + "`connect.sid`" + ` cookie, and gets 401 with ` + "`cookie 'connect.sid' required`" + `.

After this patch the same flow ends at ` + "`/`" + ` with the user logged in.